### PR TITLE
Update (k)payload/Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ $(TARGET):
 $(KTARGET):
 	cd kpayload && $(MAKE) -s
 	cp kpayload/$(KTARGET) $(KTARGET)
+	elfedit --output-type=DYN $(KTARGET)
 	
 .PHONY: clean
 clean:

--- a/kpayload/include/magic.h
+++ b/kpayload/include/magic.h
@@ -14,54 +14,56 @@
 // https://github.com/OpenOrbis/oni-framework/blob/4633038397cd524d7e6103a214cbb4935988fe2c/include/oni/utils/kdlsym/orbis505.h
 //
 
-#define __Xfast_syscall							0x1C0		// Updated from xvortex 
-#define __copyin								0x1EA710  	// Updated using fail0verflow 
+#define __Xfast_syscall							0x1c0	    // Updated from xvortex 
+#define __copyin								0x1EA710 	// Updated using fail0verflow 
 #define __copyout								0x1EA630	// Updated using fail0verflow 
-#define __printf								0x436040    // Updated using fail0verflow 
-#define __vprintf                               0x017FA0
-#define __malloc								0x10E250	// Updated using ps4-hen-vtx
-#define __free									0x3F7930    // Updated using ps4-hen-vtx
+#define __printf								0x436040	// Updated using fail0verflow 
+#define __vprintf                               0x10E250
+#define __malloc								0x4360B0	// Updated using ps4-hen-vtx
+#define __free									0x10E460	// Updated using ps4-hen-vtx
 #define __memcpy								0x1EA530	// Updated using ps4-hen-vtx
 #define __memset								0x3205C0	// Updated using ps4-hen-vtx
 #define __memcmp								0x050AC0	// Updated using ps4-hen-vtx
-#define __kmem_alloc							0xFCC80		// Updated via ChendoChap
+#define __kmem_alloc							0x0FCC80	// Updated via ChendoChap
 #define __strlen                                0x3B71A0	// Updated using ps4-hen-vtx
-#define __pause									0x261120
+#define __pause									0x3FB920
 #define __kthread_add							0x138360	// Updated using OpenOrbis
 #define __kthread_exit							0x138640	// Updated using OpenOrbis
-#define __sched_prio							0x072410
-#define __sched_add								0x072740
-#define __kern_yield							0x261440
-#define __fill_regs								0x2829C0
-#define __set_regs								0x282AF0
-#define __create_thread							0x2ECCD0
-#define __kproc_create							0x464700
-#define __kthread_set_affinity					0x4655E0
-#define __kthread_suspend_check					0x465380
-#define __kproc_kthread_add						0x465490
-#define __sx_init_flags							0x38F900
-#define __sx_xlock								0x38FA30
-#define __sx_xunlock							0x38FBC0
-#define __mtx_init								0x30E0C0
-#define __mtx_lock_spin_flags					0x30DA70
-#define __mtx_unlock_spin_flags					0x30DC30
-#define __mtx_lock_sleep						0x30D6A0
-#define __mtx_unlock_sleep						0x30D940
-#define __fpu_kern_enter						0x059580
-#define __fpu_kern_leave						0x059680
-#define __kern_reboot							0x0998A0
+#define __sched_prio							0x31EE00
+#define __sched_add								0x31F150
+#define __kern_yield							0x3FBC40
+#define __fill_regs								0x234BA0
+#define __set_regs								0x234CD0
+#define __create_thread							0x1BE1F0
+#define __kproc_create							0x137df0
+#define __kthread_set_affinity					0x138CC0
+#define __kthread_suspend_check					0x138A60
+#define __kproc_kthread_add						0x138B70
+#define __sx_init_flags							0xF5BB0
+#define __sx_xlock								0xf5e10
+#define __sx_xunlock							0xf5fd0
+#define __mtx_init								0x00402780
+#define __mtx_lock_spin_flags					0x402100
+#define __mtx_unlock_spin_flags					0x4022C0
+#define __mtx_lock_sleep						0x401CD0
+#define __mtx_unlock_sleep						0x401FA0
+#define __fpu_kern_enter						0x1BFF90
+#define __fpu_kern_leave						0x1C0090
+#define __kern_reboot							0x0010D390
 #define __vm_map_lock_read						0x19f140	// Updated using OpenOrbis
-#define __vm_map_lookup_entry					0x392C70
-#define __vm_map_unlock_read					0x392100
-#define __vmspace_free							0x391D10
-#define __vm_map_delete							0x394790
-#define __vm_map_protect						0x396860
-#define __vmspace_acquire_ref					0x19ef90	// Updated using OpenOrbis
-#define __vm_map_findspace						0x394E90
-#define __vm_map_insert							0x392F70
-#define __vm_map_lock							0x391F40
-#define __vm_map_unlock 						0x391FB0
-#define __proc_rwmem							0x17CB70
+#define __vm_map_lookup_entry					0x19F760
+#define __vm_map_unlock_read					0x19F190
+#define __vmspace_free							0x19EDC0
+#define __vm_map_delete							0x1A19D0
+#define __vm_map_protect						0x1A3A50
+#define __vmspace_acquire_ref					0x19EF90	// Updated using OpenOrbis
+#define __vm_map_findspace						0x1A1F60
+#define __vm_map_insert							0x1A0280
+#define __vm_map_lock							0x19EFF0
+#define __vm_map_unlock 						0x19F060
+#define __proc_rwmem							0x30D150
+
+
 #define __sceSblAuthMgrIsLoadable2				0x625C50
 #define __sceSblAuthMgrVerifyHeader				0x625CB0
 #define __sceSblAuthMgrGetSelfInfo				0x626490
@@ -83,10 +85,10 @@
 #define __disable_console_output                0x09ECEB0	// Updated using ExodusSecurity
 #define __M_TEMP					        	0x14B4110	// Updated using ps4-hen-vtx
 #define __kernel_map                            0x1AC60E0 	// Updated using fail0verflow 
-#define __prison0                               0x10986A0 	// Updated using AppToUsb50X
-#define __rootvnode                             0x22C1A70 	// Updated using AppToUsb50X
-#define __allproc						0x1AD7718
-#define __fpu_kern_ctx					0x251CCC0
-#define __mini_syscore_self_binary 		0x1471468
-#define __sbl_driver_mapped_pages  		0x2519DD0
-#define __sbl_keymgr_key_rbtree			0x2534DE0
+#define __prison0                               0x10986a0 	// Updated using AppToUsb50X
+#define __rootvnode                             0x22c1a70 	// Updated using AppToUsb50X
+#define __allproc								0x2382FF8
+#define __fpu_kern_ctx							0x2720840
+#define __mini_syscore_self_binary 				0x14C9D48
+#define __sbl_driver_mapped_pages  				0x271E208
+#define __sbl_keymgr_key_rbtree					0x2744558

--- a/kpayload/source/main.c
+++ b/kpayload/source/main.c
@@ -4,8 +4,8 @@
 #include "jkpayload.h"
 
 #include "rpc.h"
-#include "fself.h"
-#include "fpkg.h"
+//#include "fself.h"
+//#include "fpkg.h"
 
 void hook_trap_fatal(struct trapframe *tf) {
 	// print registers
@@ -48,7 +48,7 @@ void install_trap_hook() {
 
 	// Updated for 5.05 by ChendoChap
 	// TODO Need to understand memory addresses
-	memcpy((void *)(kernbase + 0x1718DB), "\x4C\x89\xE7", 3); // mov rdi, r12
+	memcpy((void *)(kernbase + 0x1718D8), "\x4C\x89\xE7", 3); // mov rdi, r12
 	write_jmp(kernbase + 0x1718DB, (uint64_t)hook_trap_fatal);
 
 	// restore CR0
@@ -66,11 +66,11 @@ int payload_entry(void *arg) {
 	init_rpc();
 
 	// fake self binaries
-	install_fself_hooks();
+	//install_fself_hooks();
 
 	// fake package containers
-	shellcore_fpkg_patch();
-	install_fpkg_hooks();
+	//shellcore_fpkg_patch();
+	//install_fpkg_hooks();
 
 	return 0;
 }

--- a/payload/Makefile
+++ b/payload/Makefile
@@ -1,5 +1,5 @@
 # maybe want to change to PS4SDK, I just use this to distinguish between SDKs
-LIBPS4	:=	/home/John/ps4-payload-sdk/libPS4
+LIBPS4	:=	$(PS4SDK)/libPS4
 
 TEXT	:=	0x926200000
 DATA	:=	0x926300000

--- a/payload/include/magic.h
+++ b/payload/include/magic.h
@@ -19,7 +19,7 @@
 #define __copyout								0x1EA630	// Updated using fail0verflow 
 #define __printf								0x436040    // Updated using fail0verflow 
 #define __malloc								0x10E250    // Updated using ps4-hen-vtx
-#define __free									0x3F7930    // Updated using ps4-hen-vtx
+#define __free									0x10E460    // You forgot this one!
 #define __memcpy								0x1EA530	// Updated using ps4-hen-vtx
 #define __memset								0x3205C0	// Updated using ps4-hen-vtx
 #define __memcmp								0x050AC0	// Updated using ps4-hen-vtx

--- a/payload/source/main.c
+++ b/payload/source/main.c
@@ -90,14 +90,15 @@ void scesbl_patches(struct thread *td, uint64_t kernbase) {
 	*(uint64_t *)(td_ucred + 0x68) = 0xFFFFFFFFFFFFFFFF;
 
 	// Old 4.55: *(uint8_t *)(kernbase + 0x36057B) = 0;
+	// 5.05 = 0x2461F8
 	// sceSblACMgrIsAllowedSystemLevelDebugging (updated to 5.05 using MiraFW)
-	uint8_t *kmem = (uint8_t *)&kernbase[0x00010FC0];
+	/*uint8_t *kmem = (uint8_t *)&kernbase[0x00010FC0];
 	kmem[0] = 0xB8; kmem[1] = 0x01; kmem[2] = 0x00; kmem[3] = 0x00;
 	kmem[4] = 0x00; kmem[5] = 0xC3; kmem[6] = 0x90; kmem[7] = 0x90;
-
+	// Mira patches this already
 	kmem = (uint8_t *)&kernbase[0x00011756];
 	kmem[0] = 0xB8; kmem[1] = 0x01; kmem[2] = 0x00; kmem[3] = 0x00;
-	kmem[4] = 0x00; kmem[5] = 0xC3; kmem[6] = 0x90; kmem[7] = 0x90;	
+	kmem[4] = 0x00; kmem[5] = 0xC3; kmem[6] = 0x90; kmem[7] = 0x90;	*/
 }
 
 int receive_payload(void **payload, size_t *psize) {


### PR DESCRIPTION
Kpayload:
 - Disabled HEN patches
 - Updated magic.h

Payload:
 - Disabled sceSblACMgrIsAllowedSystemLevelDebugging patch,
     - Wasn't in correct format.
     - Mira patches this.
     - The patches (4.55 jkpatch and 5.05 mira) don't seem to be the same thing, I updated the offset used in jkpatch and added it as a comment.
 - __Free in magic.h wasn't updated.
 -  The  payload\Makefile now has the ps4sdk variable.

Makefile:
 - The .ELF type of the kpayload changes to DYN now.


NOTE: Feel free to double-check the offsets and correct them if necessary 
